### PR TITLE
refactoring: func_argparser() is implemented using a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ optional arguments:
   we can't generate Argparser for them.
 - You can't have a function argument named `__command`.
 - If you don't like the generated parser, you can modify it using `override` function.
+- If you'd like to customize parser generation process:
+  - Make your own `ArgumentParser` generator by subclassing `ArgparserGenerator`
+  - Activate it by calling `set_default_generator(MyArgparserGenerator)`
 
 
 ## Alternatives


### PR DESCRIPTION
My apegears library defines a subclass of ArgumentParser.  I'd like to integrate it with the func_argparse parser generator, so that the generator can generate the my parser type.

For that, I refactored some of the func_argparse code, so it is easier to customize.  Apegears includes code to customize it for this purpose.

You can see here how it is used:
https://github.com/shx2/apegears/commit/9c72c7f7ad0f5b9a2b9442b12e0cb15e21d7f479
